### PR TITLE
Adding prompts and options for generating root configs and raw in-browser modules

### DIFF
--- a/packages/generator-single-spa/src/generator-single-spa.js
+++ b/packages/generator-single-spa/src/generator-single-spa.js
@@ -68,8 +68,8 @@ async function runFrameworkGenerator() {
     case "react":
       this.composeWith({
         Generator: SingleSpaReactGenerator,
-        path: require.resolve('./react/generator-single-spa-react.js')
-      })
+        path: require.resolve('./react/generator-single-spa-react.js'),
+      }, this.options)
       break;
     case "other":
       console.log(`Check https://github.com/CanopyTax/create-single-spa/issues for updates on new frameworks being added to create-single-spa. Feel free to create a new issue if one does not yet exist for the framework you're using.`)

--- a/packages/generator-single-spa/src/generator-single-spa.js
+++ b/packages/generator-single-spa/src/generator-single-spa.js
@@ -23,9 +23,9 @@ module.exports = class SingleSpaGenerator extends Generator {
           name: 'moduleType',
           message: 'Which kind of in-browser module do you want create-single-spa to create for you?',
           choices: [
-            { name: 'single-spa application / parcel', value: 'ss-app-parcel' },
+            { name: 'single-spa application / parcel', value: 'app-parcel' },
             { name: 'in-browser utility module (styleguide, api cache, etc)', value: 'raw-module' },
-            { name: 'single-spa root config', value: 'ss-config' },
+            { name: 'single-spa root config', value: 'root-config' },
           ]
         }
       ])
@@ -33,9 +33,9 @@ module.exports = class SingleSpaGenerator extends Generator {
       moduleType = answers.moduleType
     }
 
-    if (moduleType === 'ss-config') {
+    if (moduleType === 'root-config') {
       throw Error('root config not yet implemented')
-    } else if (moduleType === 'ss-app-parcel') {
+    } else if (moduleType === 'app-parcel') {
       await runFrameworkGenerator.call(this)
     } else if (moduleType === 'raw-module') {
       throw Error('raw module not yet implemented')

--- a/packages/generator-single-spa/src/generator-single-spa.js
+++ b/packages/generator-single-spa/src/generator-single-spa.js
@@ -21,7 +21,7 @@ module.exports = class SingleSpaGenerator extends Generator {
         {
           type: 'list',
           name: 'moduleType',
-          message: 'Which kind of in-browser module do you want create-single-spa to create for you?',
+          message: 'Select type to generate',
           choices: [
             { name: 'single-spa application / parcel', value: 'app-parcel' },
             { name: 'in-browser utility module (styleguide, api cache, etc)', value: 'raw-module' },


### PR DESCRIPTION
This sets things up for us to implement a generator for single-spa root configs and also for raw in-browser modules intended for creating styleguides, api caches, etc.

```js
npm init single-spa -- --moduleType ss-app-parcel --framework react
```