### PR TITLE
Small fixes to react and root config generators

### DIFF
--- a/packages/generator-single-spa/src/react/generator-single-spa-react.js
+++ b/packages/generator-single-spa/src/react/generator-single-spa-react.js
@@ -71,6 +71,11 @@ module.exports = class SingleSpaReactGenerator extends Generator {
       templateOptions
     )
     this.fs.copyTpl(
+      this.templatePath('.prettierignore'),
+      this.destinationPath('.prettierignore'),
+      templateOptions
+    )
+    this.fs.copyTpl(
       this.templatePath('webpack.config.js'),
       this.destinationPath('webpack.config.js'),
       templateOptions

--- a/packages/generator-single-spa/src/react/templates/.prettierignore
+++ b/packages/generator-single-spa/src/react/templates/.prettierignore
@@ -1,0 +1,4 @@
+.gitignore
+.prettierignore
+yarn.lock
+package-lock.json

--- a/packages/generator-single-spa/src/react/templates/package.json
+++ b/packages/generator-single-spa/src/react/templates/package.json
@@ -11,7 +11,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && concurrently <%= packageManager %>:test <%= packageManager %>:lint <%= packageManager %>:typescript <%= packageManager %>:coverage"
+      "pre-commit": "pretty-quick --staged && concurrently <%= packageManager %>:test <%= packageManager %>:lint"
     }
   },
   "devDependencies": {

--- a/packages/generator-single-spa/src/root-config/generator-root-config.js
+++ b/packages/generator-single-spa/src/root-config/generator-root-config.js
@@ -46,6 +46,20 @@ module.exports = class SingleSpaRootConfigGenerator extends Generator {
     ])
 
     this.fs.copyTpl(
+      this.templatePath('.eslintrc'),
+      this.destinationPath('.eslintrc'),
+      templateOptions,
+      {delimiter: '?'}
+    )
+
+    this.fs.copyTpl(
+      this.templatePath('.prettierignore'),
+      this.destinationPath('.prettierignore'),
+      templateOptions,
+      {delimiter: '?'}
+    )
+
+    this.fs.copyTpl(
       this.templatePath(),
       this.destinationPath(),
       templateOptions,

--- a/packages/generator-single-spa/src/root-config/templates/.prettierignore
+++ b/packages/generator-single-spa/src/root-config/templates/.prettierignore
@@ -1,0 +1,4 @@
+.gitignore
+.prettierignore
+yarn.lock
+package-lock.json

--- a/packages/generator-single-spa/src/root-config/templates/package.json
+++ b/packages/generator-single-spa/src/root-config/templates/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "start": "webpack-dev-server --mode=development --port 9000 --env.local=true",
+    "start": "webpack-dev-server --mode=development --port 9000 --env.isLocal=true",
     "lint": "eslint src",
     "test": "jest",
     "build": "webpack --mode=production"

--- a/packages/generator-single-spa/test/react.test.js
+++ b/packages/generator-single-spa/test/react.test.js
@@ -25,7 +25,7 @@ describe('generator-single-spa', () => {
       assert.jsonFileContent(path.join(dir, 'package.json'), {
         husky: {
           hooks: {
-            "pre-commit": "pretty-quick --staged && concurrently yarn:test yarn:lint yarn:typescript yarn:coverage"
+            "pre-commit": "pretty-quick --staged && concurrently yarn:test yarn:lint"
           }
         }
       })
@@ -46,7 +46,7 @@ describe('generator-single-spa', () => {
       assert.jsonFileContent(path.join(dir, 'package.json'), {
         husky: {
           hooks: {
-            "pre-commit": "pretty-quick --staged && concurrently npm:test npm:lint npm:typescript npm:coverage"
+            "pre-commit": "pretty-quick --staged && concurrently npm:test npm:lint"
           }
         }
       })

--- a/packages/generator-single-spa/test/root-config.test.js
+++ b/packages/generator-single-spa/test/root-config.test.js
@@ -22,6 +22,10 @@ describe('generator-single-spa', () => {
       })
 
     return runContext.then(dir => {
+      assert.file(path.join(dir, 'package.json'))
+      assert.file(path.join(dir, ".eslintrc"))
+      assert.file(path.join(dir, ".prettierignore"))
+
       // The webpack config should have their org name in its webpack externals
       assert.file(path.join(dir, "webpack.config.js"))
       const webpackConfigAsStr = fs.readFileSync(path.join(dir, 'webpack.config.js'), {encoding: "utf-8"})

--- a/packages/generator-single-spa/test/root-config.test.js
+++ b/packages/generator-single-spa/test/root-config.test.js
@@ -23,6 +23,7 @@ describe('generator-single-spa', () => {
 
     return runContext.then(dir => {
       assert.file(path.join(dir, 'package.json'))
+      assert.file(path.join(dir, ".prettierignore"))
 
       // The webpack config should have their org name in its webpack externals
       assert.file(path.join(dir, "webpack.config.js"))

--- a/packages/generator-single-spa/test/root-config.test.js
+++ b/packages/generator-single-spa/test/root-config.test.js
@@ -22,9 +22,6 @@ describe('generator-single-spa', () => {
       })
 
     return runContext.then(dir => {
-      assert.file(path.join(dir, 'package.json'))
-      assert.file(path.join(dir, ".prettierignore"))
-
       // The webpack config should have their org name in its webpack externals
       assert.file(path.join(dir, "webpack.config.js"))
       const webpackConfigAsStr = fs.readFileSync(path.join(dir, 'webpack.config.js'), {encoding: "utf-8"})


### PR DESCRIPTION
These were fixes I discovered when running create-single-spa on the react microfrontends example. See related https://github.com/react-microfrontends/nav-bar/pull/2 and https://github.com/react-microfrontends/root-config/pull/1